### PR TITLE
fix: add allowed hosts configuration to SDK templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Features:
 - Example tool (`start-notification-stream`)
 - Example resource (`greeting-resource`)
 - TypeScript configuration
-- Environment variable support for PORT
+- Environment variable support for PORT and ALLOWED_HOSTS
 
 #### sdk/stateful
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentailor/create-mcp-server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentailor/create-mcp-server",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentailor/create-mcp-server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Create a new MCP (Model Context Protocol) server project",
   "type": "module",
   "bin": {

--- a/src/templates/common/env.example.ts
+++ b/src/templates/common/env.example.ts
@@ -2,6 +2,14 @@ import type { CommonTemplateOptions } from './types.js';
 
 export function getEnvExampleTemplate(options?: CommonTemplateOptions): string {
   const withOAuth = options?.withOAuth ?? false;
+  const isSdk = options?.framework === 'sdk' || !options?.framework;
+
+  const allowedHostsVar = isSdk
+    ? `
+# Comma-separated list of additional allowed hosts (for deployment behind reverse proxies)
+# ALLOWED_HOSTS=my-server.example.com,my-server.us-central1.run.app
+`
+    : '';
 
   const oauthVars = withOAuth
     ? `
@@ -19,5 +27,5 @@ OAUTH_AUDIENCE=https://your-mcp-server.com
     : '';
 
   return `PORT=3000
-${oauthVars}`;
+${allowedHostsVar}${oauthVars}`;
 }

--- a/src/templates/common/templates.test.ts
+++ b/src/templates/common/templates.test.ts
@@ -105,5 +105,20 @@ describe('common templates', () => {
       const template = getEnvExampleTemplate();
       expect(template).toContain('PORT=');
     });
+
+    it('should include ALLOWED_HOSTS hint for SDK framework', () => {
+      const template = getEnvExampleTemplate({ framework: 'sdk' });
+      expect(template).toContain('ALLOWED_HOSTS');
+    });
+
+    it('should include ALLOWED_HOSTS hint by default (no framework specified)', () => {
+      const template = getEnvExampleTemplate();
+      expect(template).toContain('ALLOWED_HOSTS');
+    });
+
+    it('should NOT include ALLOWED_HOSTS for FastMCP framework', () => {
+      const template = getEnvExampleTemplate({ framework: 'fastmcp' });
+      expect(template).not.toContain('ALLOWED_HOSTS');
+    });
   });
 });

--- a/src/templates/sdk/stateful/index.ts
+++ b/src/templates/sdk/stateful/index.ts
@@ -18,14 +18,19 @@ import {
   getOAuthMetadataUrl,
   validateOAuthConfig,
 } from './auth.js';`
-    : `import { type Request, type Response } from 'express';
+    : `import 'dotenv/config';
+import { type Request, type Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { getServer } from './server.js';`;
 
-  const appSetup = `const app = createMcpExpressApp();
+  const appSetup = `const allowedHosts = process.env.ALLOWED_HOSTS?.split(',') ?? [];
+
+const app = createMcpExpressApp({
+  allowedHosts: ['localhost', '127.0.0.1', '[::1]', ...allowedHosts],
+});
 
 // Health check endpoint for container orchestration
 app.get('/health', (_, res) => res.sendStatus(200));`;

--- a/src/templates/sdk/stateful/readme.ts
+++ b/src/templates/sdk/stateful/readme.ts
@@ -143,7 +143,7 @@ ${commands.build}
 ${commands.start}
 \`\`\`
 
-The server will start on port 3000 by default. You can change this by setting the \`PORT\` environment variable.
+The server will start on port 3000 by default. You can change this by setting the \`PORT\` environment variable. To allow additional hosts (e.g. when deploying behind a reverse proxy), set \`ALLOWED_HOSTS\` as a comma-separated list.
 
 ## Testing with MCP Inspector
 

--- a/src/templates/sdk/stateful/templates.test.ts
+++ b/src/templates/sdk/stateful/templates.test.ts
@@ -44,7 +44,7 @@ describe('sdk/stateful templates', () => {
     it('should use createMcpExpressApp', () => {
       const template = getIndexTemplate();
       expect(template).toContain('createMcpExpressApp');
-      expect(template).toContain('const app = createMcpExpressApp()');
+      expect(template).toContain('const app = createMcpExpressApp({');
     });
 
     it('should configure /mcp endpoint', () => {
@@ -56,7 +56,13 @@ describe('sdk/stateful templates', () => {
 
     it('should use PORT from environment variable', () => {
       const template = getIndexTemplate();
-      expect(template).toContain('process.env.PORT || 3000');
+      expect(template).toContain('process.env.PORT');
+    });
+
+    it('should pass allowedHosts to createMcpExpressApp', () => {
+      const template = getIndexTemplate();
+      expect(template).toContain('allowedHosts');
+      expect(template).toContain("ALLOWED_HOSTS?.split(',')");
     });
 
     // Stateful-specific tests

--- a/src/templates/sdk/stateless/index.ts
+++ b/src/templates/sdk/stateless/index.ts
@@ -10,7 +10,11 @@ import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { getServer } from './server.js';
 
-const app = createMcpExpressApp();
+const allowedHosts = process.env.ALLOWED_HOSTS?.split(',') ?? [];
+
+const app = createMcpExpressApp({
+  allowedHosts: ['localhost', '127.0.0.1', '[::1]', ...allowedHosts],
+});
 
 // Health check endpoint for container orchestration
 app.get('/health', (_, res) => res.sendStatus(200));

--- a/src/templates/sdk/stateless/readme.ts
+++ b/src/templates/sdk/stateless/readme.ts
@@ -49,7 +49,7 @@ ${commands.build}
 ${commands.start}
 \`\`\`
 
-The server will start on port 3000 by default. You can change this by setting the \`PORT\` environment variable.
+The server will start on port 3000 by default. You can change this by setting the \`PORT\` environment variable. To allow additional hosts (e.g. when deploying behind a reverse proxy), set \`ALLOWED_HOSTS\` as a comma-separated list.
 
 ## Testing with MCP Inspector
 

--- a/src/templates/sdk/stateless/templates.test.ts
+++ b/src/templates/sdk/stateless/templates.test.ts
@@ -44,7 +44,7 @@ describe('sdk/stateless templates', () => {
     it('should use createMcpExpressApp', () => {
       const template = getIndexTemplate();
       expect(template).toContain('createMcpExpressApp');
-      expect(template).toContain('const app = createMcpExpressApp()');
+      expect(template).toContain('const app = createMcpExpressApp({');
     });
 
     it('should configure /mcp endpoint', () => {
@@ -56,7 +56,13 @@ describe('sdk/stateless templates', () => {
 
     it('should use PORT from environment variable', () => {
       const template = getIndexTemplate();
-      expect(template).toContain('process.env.PORT || 3000');
+      expect(template).toContain('process.env.PORT');
+    });
+
+    it('should pass allowedHosts to createMcpExpressApp', () => {
+      const template = getIndexTemplate();
+      expect(template).toContain('allowedHosts');
+      expect(template).toContain("ALLOWED_HOSTS?.split(',')");
     });
 
     // Stateless-specific tests


### PR DESCRIPTION
## Summary
- Add `allowedHosts` to `createMcpExpressApp()` in SDK stateless and stateful templates to support DNS rebinding protection
- Default allowed hosts: `localhost`, `127.0.0.1`, `[::1]`
- Users can extend via `ALLOWED_HOSTS` env var (comma-separated)
- Fix missing `import 'dotenv/config'` in stateful template (non-OAuth path)
- Update SDK README templates to document `ALLOWED_HOSTS`

## Test plan
- [x] All 144 tests passing
- [x] Build succeeds
- [x] Generated SDK project includes `allowedHosts` in `createMcpExpressApp()`
