### PR TITLE
fix: return 401 instead of 500 for rejected OAuth tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,8 @@ OAuth is orthogonal to the template type and applies to any SDK HTTP project. Wh
 - Protected resource metadata endpoint at `/.well-known/oauth-protected-resource`
 - Server startup validation ensures OAuth provider is reachable
 - `requireBearerAuth` attaches `AuthInfo` to `req.auth`; `toNodeHandler` forwards it to handlers as `ctx.http.authInfo`
+- **The verifier must throw `OAuthError`, never a plain `Error`.** `requireBearerAuth` maps only `OAuthError` to a `401` + `WWW-Authenticate` challenge; anything else becomes a `500 server_error` with no challenge header, leaving clients no signal to re-authenticate. `auth.ts` therefore converts every `jose` failure (bad signature, expired, wrong issuer/audience) into `new OAuthError(OAuthErrorCode.InvalidToken, ...)`. Note `OAuthError`/`OAuthErrorCode` are **value** exports of `@modelcontextprotocol/server` — import them alongside, not inside, the existing `import type` line.
+- The 401 body is a fixed `'Token verification failed'` rather than the `jose` message, so callers can't probe *why* a token was rejected; the specific reason still goes to the server log. The `!JWKS` guard stays a plain `Error` on purpose — that is a server misconfiguration and belongs in the 500 bucket.
 - See [docs/oauth-setup.md](docs/oauth-setup.md) for provider-specific setup instructions
 
 #### sdk/stdio

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -34,6 +34,15 @@ When a client sends a request with `Authorization: Bearer <token>`:
 4. Checks the `aud` (audience) claim if `OAUTH_AUDIENCE` is configured
 5. Verifies the token has not expired (`exp` claim)
 
+If any step fails, the verifier throws an `OAuthError` with code `invalid_token`. The
+server answers **`401`** with a `WWW-Authenticate: Bearer` challenge that points at the
+protected resource metadata, so clients know to re-authenticate.
+
+The response body deliberately says only `"Token verification failed"` — it does not
+reveal whether the signature, issuer, audience, or expiry was at fault. **The specific
+reason is written to the server log** as `[auth] JWT verification failed: <reason>`, so
+check there when debugging a rejected token.
+
 ## Provider Requirements
 
 Your OIDC provider must:
@@ -74,6 +83,11 @@ Consult your provider's documentation to configure these settings.
    ```
 
 ## Troubleshooting
+
+A rejected token always returns the same `401` body, so diagnose from the **server log**
+line `[auth] JWT verification failed: <reason>`. The `<reason>` comes from `jose` — for
+example `signature verification failed`, `"exp" claim timestamp check failed`, or
+`unexpected "iss" claim value`. The sections below are keyed on that reason.
 
 ### "Token is not a valid JWT format"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentailor/create-mcp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentailor/create-mcp-server",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentailor/create-mcp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Create a new MCP (Model Context Protocol) server project",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ export interface ParseResult {
 }
 
 const NAME_REGEX = /^[a-z0-9-_]+$/i;
-const VERSION = '0.7.0';
+const VERSION = '0.7.1';
 
 function validateName(value: string): string {
   if (!NAME_REGEX.test(value)) {

--- a/src/templates/sdk/stateful/auth.test.ts
+++ b/src/templates/sdk/stateful/auth.test.ts
@@ -119,5 +119,52 @@ describe('auth template', () => {
       const template = getAuthTemplate();
       expect(template).toContain("jwtPayload.scope.split(' ')");
     });
+
+    it('should import OAuthError and OAuthErrorCode as values, not types', () => {
+      const template = getAuthTemplate();
+      expect(template).toContain(
+        "import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server'"
+      );
+    });
+
+    it('should reject malformed JWTs with an OAuthError so the response is 401', () => {
+      const template = getAuthTemplate();
+      expect(template).toContain('throw new OAuthError(\n          OAuthErrorCode.InvalidToken,');
+      expect(template).not.toContain(
+        "throw new Error(\n          'Token is not a valid JWT format"
+      );
+    });
+
+    it('should convert jose verification failures into an OAuthError', () => {
+      const template = getAuthTemplate();
+      expect(template).toContain(
+        "throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token verification failed')"
+      );
+      // The bare re-throw produced a 500 server_error with no WWW-Authenticate header.
+      expect(template).not.toMatch(
+        /JWT verification failed:', error\.message\);\s*}\s*throw error;/
+      );
+    });
+
+    it('should re-throw an existing OAuthError unchanged', () => {
+      const template = getAuthTemplate();
+      expect(template).toContain('if (error instanceof OAuthError) {');
+    });
+
+    it('should not leak the underlying failure reason into the error response', () => {
+      const template = getAuthTemplate();
+      // The jose message is logged server-side but must not reach error_description.
+      expect(template).toContain("console.error('[auth] JWT verification failed:', error.message)");
+      expect(template).not.toContain(
+        "error instanceof Error ? error.message : 'Token verification failed'"
+      );
+    });
+
+    it('should keep an uninitialized JWKS as a plain Error (server misconfiguration)', () => {
+      const template = getAuthTemplate();
+      expect(template).toContain(
+        "throw new Error('JWKS not initialized. Call validateOAuthConfig() first.')"
+      );
+    });
   });
 });

--- a/src/templates/sdk/stateful/auth.ts
+++ b/src/templates/sdk/stateful/auth.ts
@@ -6,6 +6,7 @@ import {
   getOAuthProtectedResourceMetadataUrl,
   requireBearerAuth,
 } from '@modelcontextprotocol/express';
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
 import type { OAuthMetadata, OAuthTokenVerifier } from '@modelcontextprotocol/server';
 import type { Express, RequestHandler } from 'express';
 
@@ -47,6 +48,8 @@ interface OIDCDiscoveryDocument {
 // Token verifier using JWKS/JWT validation
 const tokenVerifier: OAuthTokenVerifier = {
   verifyAccessToken: async (token: string) => {
+    // A plain Error here is intentional: an uninitialized JWKS is a server
+    // misconfiguration, not a bad token, so it should surface as 500 server_error.
     if (!JWKS) {
       throw new Error('JWKS not initialized. Call validateOAuthConfig() first.');
     }
@@ -55,8 +58,9 @@ const tokenVerifier: OAuthTokenVerifier = {
       // Check if the token looks like a JWT (three base64url-encoded parts separated by dots)
       const parts = token.split('.');
       if (parts.length !== 3) {
-        throw new Error(
-          'Token is not a valid JWT format (expected 3 parts separated by dots). '
+        throw new OAuthError(
+          OAuthErrorCode.InvalidToken,
+          'Token is not a valid JWT format (expected 3 parts separated by dots).'
         );
       }
 
@@ -83,7 +87,14 @@ const tokenVerifier: OAuthTokenVerifier = {
       if (error instanceof Error) {
         console.error('[auth] JWT verification failed:', error.message);
       }
-      throw error;
+      if (error instanceof OAuthError) {
+        throw error;
+      }
+      // Convert jose failures (bad signature, expired, wrong issuer/audience) into
+      // an OAuthError so requireBearerAuth answers 401 with a WWW-Authenticate
+      // challenge instead of 500. The specific reason stays in the server log
+      // rather than the response body, so callers learn nothing beyond "invalid".
+      throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token verification failed');
     }
   },
 };


### PR DESCRIPTION
Fixes #27.

`requireBearerAuth` maps only `OAuthError` to a 401 challenge. The OAuth template's verifier threw plain `Error`s, so rejected tokens came back as `500 server_error` with no `WWW-Authenticate` header — clients had no signal to re-authenticate. Affects every `--oauth` scaffold.

Both throw sites now raise `OAuthError(OAuthErrorCode.InvalidToken, …)`. `OAuthError`/`OAuthErrorCode` are **value** exports of `@modelcontextprotocol/server` — the template previously only pulled them in via `import type`, which erases at compile time.

## Two judgement calls

**The 401 body is a fixed `"Token verification failed"`,** not the jose message #27 suggested forwarding. Forwarding tells an unauthenticated caller *which* check failed — expired vs. wrong issuer vs. forged signature — which is a probing oracle. The specific reason still goes to the server log, so operators lose nothing. Docs updated to point at `[auth] JWT verification failed: <reason>`, since the Troubleshooting section was keyed on strings that no longer reach the client.

**The `!JWKS` guard stays a plain `Error`.** That's a server misconfiguration, not a bad token, so 500 is correct there.

## Verification

Scaffolded a project, installed the real SDK v2, ran it against a mock OIDC issuer with RS256 keys. Reproduced the 500 first, then confirmed the fix:

| Case | Before | After |
|---|---|---|
| Valid token | 200 | 200 |
| Tampered signature | **500** | 401 + `WWW-Authenticate` |
| Expired token | **500** | 401 + `WWW-Authenticate` |
| Wrong issuer | **500** | 401 + `WWW-Authenticate` |
| Malformed token | 500 | 401 + `WWW-Authenticate` |
| No auth header | 401 | 401 |

Expired and wrong-issuer were also 500s — #27 predicted this but only tested tampered/malformed. The generated project type-checks against `@modelcontextprotocol/server@2.0.0`, which is what proves the value-vs-type import mattered.

378 tests pass (6 new), lint clean. Version bumped to 0.7.1.
